### PR TITLE
Add Prometheus rule generators for metrics aggregated by sloth ID

### DIFF
--- a/internal/prometheus/recording_rules.go
+++ b/internal/prometheus/recording_rules.go
@@ -26,6 +26,10 @@ type sliRecordingRulesGenerator struct {
 // Normally these rules are used by the SLO alerts.
 var OptimizedSLIRecordingRulesGenerator = sliRecordingRulesGenerator{genFunc: optimizedFactorySLIRecordGenerator}
 
+// OptimizedBySlothIDSLIRecordingRulesGenerator knows how to generate the SLI prometheus recording rules
+// from an SLO optimizing where it can and aggregating by sloth_id to allow changes to other labels without breaking.
+var OptimizedBySlothIDSLIRecordingRulesGenerator = sliRecordingRulesGenerator{genFunc: optimizedFactorySLIBySlothIDRecordGenerator}
+
 // SLIRecordingRulesGenerator knows how to generate the SLI prometheus recording rules
 // form an SLO.
 // Normally these rules are used by the SLO alerts.
@@ -35,6 +39,15 @@ func optimizedFactorySLIRecordGenerator(slo SLO, window time.Duration, alerts al
 	// Optimize the rules that are for the total period time window.
 	if window == slo.TimeWindow {
 		return optimizedSLIRecordGenerator(slo, window, alerts.PageQuick.ShortWindow)
+	}
+
+	return factorySLIRecordGenerator(slo, window, alerts)
+}
+
+func optimizedFactorySLIBySlothIDRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBAlertGroup) (*rulefmt.Rule, error) {
+	// Optimize the rules that are for the total period time window.
+	if window == slo.TimeWindow {
+		return optimizedBySlothIDSLIRecordGenerator(slo, window, alerts.PageQuick.ShortWindow)
 	}
 
 	return factorySLIRecordGenerator(slo, window, alerts)
@@ -196,6 +209,56 @@ count_over_time({{.metric}}{{.filter}}[{{.window}}])
 	}, nil
 }
 
+// optimizedBySlothIDSLIRecordGenerator generates the same optimized SLI recording rule as optimizedSLIRecordGenerator,
+// just aggregates by the sloth_id label to allow changes to other labels without breaking.
+func optimizedBySlothIDSLIRecordGenerator(slo SLO, window, shortWindow time.Duration) (*rulefmt.Rule, error) {
+	// Averages over ratios (average over average) is statistically incorrect, so we do
+	// aggregate all ratios on the time window and then divide with the aggregation of all the full ratios
+	// that is 1 (thats why we can use `count`), giving use a correct ratio of ratios:
+	// - https://prometheus.io/docs/practices/rules/
+	// - https://math.stackexchange.com/questions/95909/why-is-an-average-of-an-average-usually-incorrect
+	const sliExprTplFmt = `sum by (sloth_id) (sum_over_time({{.metric}}{{.filter}}[{{.window}}]))
+/
+sum by (sloth_id) (count_over_time({{.metric}}{{.filter}}[{{.window}}]))
+`
+
+	if window == shortWindow {
+		return nil, fmt.Errorf("can't optimize using the same shortwindow as the window to optimize")
+	}
+
+	shortWindowSLIRec := slo.GetSLIErrorMetric(shortWindow)
+
+	// Render with our templated data.
+	tpl, err := template.New("sliExpr").Option("missingkey=error").Parse(sliExprTplFmt)
+	if err != nil {
+		return nil, fmt.Errorf("could not create SLI expression template data: %w", err)
+	}
+
+	strWindow := timeDurationToPromStr(window)
+	var b bytes.Buffer
+	err = tpl.Execute(&b, map[string]string{
+		"metric":    shortWindowSLIRec,
+		"filter":    slothIDFilter(slo.ID),
+		"window":    strWindow,
+		"windowKey": sloWindowLabelName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not render SLI expression template: %w", err)
+	}
+
+	return &rulefmt.Rule{
+		Record: slo.GetSLIErrorMetric(window),
+		Expr:   b.String(),
+		Labels: mergeLabels(
+			slo.GetSLOIDPromLabels(),
+			map[string]string{
+				sloWindowLabelName: strWindow,
+			},
+			slo.Labels,
+		),
+	}, nil
+}
+
 type metadataRecordingRulesGenerator bool
 
 // MetadataRecordingRulesGenerator knows how to generate the metadata prometheus recording rules
@@ -305,7 +368,125 @@ func (m metadataRecordingRulesGenerator) GenerateMetadataRecordingRules(ctx cont
 	return rules, nil
 }
 
+type metadataRecordingRulesBySlothIDGenerator bool
+
+// MetadataRecordingRulesBySlothIDGenerator knows how to generate the metadata prometheus recording rules
+// from an SLO aggregating by sloth_id to allow changes to other labels without breaking.
+const MetadataRecordingRulesBySlothIDGenerator = metadataRecordingRulesBySlothIDGenerator(false)
+
+func (m metadataRecordingRulesBySlothIDGenerator) GenerateMetadataRecordingRules(ctx context.Context, info info.Info, slo SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+	labels := mergeLabels(slo.GetSLOIDPromLabels(), slo.Labels)
+
+	// Metatada Recordings.
+	const (
+		metricSLOObjectiveRatio                  = "slo:objective:ratio"
+		metricSLOErrorBudgetRatio                = "slo:error_budget:ratio"
+		metricSLOTimePeriodDays                  = "slo:time_period:days"
+		metricSLOCurrentBurnRateRatio            = "slo:current_burn_rate:ratio"
+		metricSLOPeriodBurnRateRatio             = "slo:period_burn_rate:ratio"
+		metricSLOPeriodErrorBudgetRemainingRatio = "slo:period_error_budget_remaining:ratio"
+		metricSLOInfo                            = "sloth_slo_info"
+	)
+
+	sloObjectiveRatio := slo.Objective / 100
+
+	sloFilter := slothIDFilter(slo.ID)
+
+	var currentBurnRateExpr bytes.Buffer
+	err := burnRateRecordingBySlothIDExprTpl.Execute(&currentBurnRateExpr, map[string]string{
+		"SLIErrorMetric":         slo.GetSLIErrorMetric(alerts.PageQuick.ShortWindow),
+		"MetricFilter":           sloFilter,
+		"SLOIDName":              sloIDLabelName,
+		"SLOLabelName":           sloNameLabelName,
+		"SLOServiceName":         sloServiceLabelName,
+		"ErrorBudgetRatioMetric": metricSLOErrorBudgetRatio,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not render current burn rate prometheus metadata recording rule expression: %w", err)
+	}
+
+	var periodBurnRateExpr bytes.Buffer
+	err = burnRateRecordingBySlothIDExprTpl.Execute(&periodBurnRateExpr, map[string]string{
+		"SLIErrorMetric":         slo.GetSLIErrorMetric(slo.TimeWindow),
+		"MetricFilter":           sloFilter,
+		"SLOIDName":              sloIDLabelName,
+		"SLOLabelName":           sloNameLabelName,
+		"SLOServiceName":         sloServiceLabelName,
+		"ErrorBudgetRatioMetric": metricSLOErrorBudgetRatio,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not render period burn rate prometheus metadata recording rule expression: %w", err)
+	}
+
+	rules := []rulefmt.Rule{
+		// SLO Objective.
+		{
+			Record: metricSLOObjectiveRatio,
+			Expr:   fmt.Sprintf(`vector(%g)`, sloObjectiveRatio),
+			Labels: labels,
+		},
+
+		// Error budget.
+		{
+			Record: metricSLOErrorBudgetRatio,
+			Expr:   fmt.Sprintf(`vector(1-%g)`, sloObjectiveRatio),
+			Labels: labels,
+		},
+
+		// Total period.
+		{
+			Record: metricSLOTimePeriodDays,
+			Expr:   fmt.Sprintf(`vector(%g)`, slo.TimeWindow.Hours()/24),
+			Labels: labels,
+		},
+
+		// Current burning speed.
+		{
+			Record: metricSLOCurrentBurnRateRatio,
+			Expr:   currentBurnRateExpr.String(),
+			Labels: labels,
+		},
+
+		// Total period burn rate.
+		{
+			Record: metricSLOPeriodBurnRateRatio,
+			Expr:   periodBurnRateExpr.String(),
+			Labels: labels,
+		},
+
+		// Total Error budget remaining period.
+		{
+			Record: metricSLOPeriodErrorBudgetRemainingRatio,
+			Expr:   fmt.Sprintf(`1 - max(%s%s)`, metricSLOPeriodBurnRateRatio, sloFilter),
+			Labels: labels,
+		},
+
+		// Info.
+		{
+			Record: metricSLOInfo,
+			Expr:   `vector(1)`,
+			Labels: mergeLabels(labels, map[string]string{
+				sloVersionLabelName:   info.Version,
+				sloModeLabelName:      string(info.Mode),
+				sloSpecLabelName:      info.Spec,
+				sloObjectiveLabelName: strconv.FormatFloat(slo.Objective, 'f', -1, 64),
+			}),
+		},
+	}
+
+	return rules, nil
+}
+
 var burnRateRecordingExprTpl = template.Must(template.New("burnRateExpr").Option("missingkey=error").Parse(`{{ .SLIErrorMetric }}{{ .MetricFilter }}
 / on({{ .SLOIDName }}, {{ .SLOLabelName }}, {{ .SLOServiceName }}) group_left
 {{ .ErrorBudgetRatioMetric }}{{ .MetricFilter }}
 `))
+
+var burnRateRecordingBySlothIDExprTpl = template.Must(template.New("burnRateExpr").Option("missingkey=error").Parse(`max({{ .SLIErrorMetric }}{{ .MetricFilter }})
+/
+max({{ .ErrorBudgetRatioMetric }}{{ .MetricFilter }})
+`))
+
+func slothIDFilter(sloID string) string {
+	return fmt.Sprintf(`{sloth_id=%q}`, sloID)
+}

--- a/internal/prometheus/recording_rules_test.go
+++ b/internal/prometheus/recording_rules_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/slok/sloth/internal/alert"
+	"github.com/slok/sloth/internal/app/generate"
 	"github.com/slok/sloth/internal/info"
 	"github.com/slok/sloth/internal/prometheus"
 )
@@ -187,6 +188,116 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				{
 					Record: "slo:sli_error:ratio_rate30d",
 					Expr:   "sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+						"sloth_window":  "30d",
+					},
+				},
+			},
+		},
+
+		"Having an SLO with SLI(events) and its mwmb alerts should create the recording rules aggregated by sloth id.": {
+			generator: func() generator { return prometheus.OptimizedBySlothIDSLIRecordingRulesGenerator },
+			slo: prometheus.SLO{
+				ID:         "test",
+				Name:       "test-name",
+				Service:    "test-svc",
+				TimeWindow: 30 * 24 * time.Hour,
+				SLI: prometheus.SLI{
+					Events: &prometheus.SLIEvents{
+						ErrorQuery: `rate(my_metric[{{.window}}]{error="true"})`,
+						TotalQuery: `rate(my_metric[{{.window}}])`,
+					},
+				},
+				Labels: map[string]string{
+					"kind": "test",
+				},
+			},
+			alertGroup: getAlertGroup(),
+			expRules: []rulefmt.Rule{
+				{
+					Record: "slo:sli_error:ratio_rate5m",
+					Expr:   "(rate(my_metric[5m]{error=\"true\"}))\n/\n(rate(my_metric[5m]))\n",
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+						"sloth_window":  "5m",
+					},
+				},
+				{
+					Record: "slo:sli_error:ratio_rate30m",
+					Expr:   "(rate(my_metric[30m]{error=\"true\"}))\n/\n(rate(my_metric[30m]))\n",
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+						"sloth_window":  "30m",
+					},
+				},
+				{
+					Record: "slo:sli_error:ratio_rate1h",
+					Expr:   "(rate(my_metric[1h]{error=\"true\"}))\n/\n(rate(my_metric[1h]))\n",
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+						"sloth_window":  "1h",
+					},
+				},
+				{
+					Record: "slo:sli_error:ratio_rate2h",
+					Expr:   "(rate(my_metric[2h]{error=\"true\"}))\n/\n(rate(my_metric[2h]))\n",
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+						"sloth_window":  "2h",
+					},
+				},
+				{
+					Record: "slo:sli_error:ratio_rate6h",
+					Expr:   "(rate(my_metric[6h]{error=\"true\"}))\n/\n(rate(my_metric[6h]))\n",
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+						"sloth_window":  "6h",
+					},
+				},
+				{
+					Record: "slo:sli_error:ratio_rate1d",
+					Expr:   "(rate(my_metric[1d]{error=\"true\"}))\n/\n(rate(my_metric[1d]))\n",
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+						"sloth_window":  "1d",
+					},
+				},
+				{
+					Record: "slo:sli_error:ratio_rate3d",
+					Expr:   "(rate(my_metric[3d]{error=\"true\"}))\n/\n(rate(my_metric[3d]))\n",
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+						"sloth_window":  "3d",
+					},
+				},
+				{
+					Record: "slo:sli_error:ratio_rate30d",
+					Expr:   "sum by (sloth_id) (sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\"}[30d]))\n/\nsum by (sloth_id) (count_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\"}[30d]))\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -506,6 +617,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 
 func TestGenerateMetaRecordingRules(t *testing.T) {
 	tests := map[string]struct {
+		generator  generate.MetadataRecordingRulesGenerator
 		info       info.Info
 		slo        prometheus.SLO
 		alertGroup alert.MWMBAlertGroup
@@ -513,6 +625,7 @@ func TestGenerateMetaRecordingRules(t *testing.T) {
 		expErr     bool
 	}{
 		"Having and SLO an its mwmb alerts should create the metadata recording rules.": {
+			generator: prometheus.MetadataRecordingRulesGenerator,
 			info: info.Info{
 				Version: "test-ver",
 				Mode:    info.ModeTest,
@@ -612,13 +725,114 @@ slo:error_budget:ratio{sloth_id="test", sloth_service="test-svc", sloth_slo="tes
 				},
 			},
 		},
+		"Having and SLO an its mwmb alerts should create the metadata recording rules aggregated by sloth id.": {
+			generator: prometheus.MetadataRecordingRulesBySlothIDGenerator,
+			info: info.Info{
+				Version: "test-ver",
+				Mode:    info.ModeTest,
+				Spec:    "test/v1",
+			},
+			slo: prometheus.SLO{
+				ID:         "test",
+				Name:       "test-name",
+				Service:    "test-svc",
+				Objective:  99.9,
+				TimeWindow: 30 * 24 * time.Hour,
+				Labels: map[string]string{
+					"kind": "test",
+				},
+			},
+			alertGroup: getAlertGroup(),
+			expRules: []rulefmt.Rule{
+				{
+					Record: "slo:objective:ratio",
+					Expr:   "vector(0.9990000000000001)",
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+					},
+				},
+				{
+					Record: "slo:error_budget:ratio",
+					Expr:   "vector(1-0.9990000000000001)",
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+					},
+				},
+				{
+					Record: "slo:time_period:days",
+					Expr:   "vector(30)",
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+					},
+				},
+				{
+					Record: "slo:current_burn_rate:ratio",
+					Expr: `max(slo:sli_error:ratio_rate5m{sloth_id="test"})
+/
+max(slo:error_budget:ratio{sloth_id="test"})
+`,
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+					},
+				},
+				{
+					Record: "slo:period_burn_rate:ratio",
+					Expr: `max(slo:sli_error:ratio_rate30d{sloth_id="test"})
+/
+max(slo:error_budget:ratio{sloth_id="test"})
+`,
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+					},
+				},
+				{
+					Record: "slo:period_error_budget_remaining:ratio",
+					Expr:   `1 - max(slo:period_burn_rate:ratio{sloth_id="test"})`,
+					Labels: map[string]string{
+						"kind":          "test",
+						"sloth_service": "test-svc",
+						"sloth_slo":     "test-name",
+						"sloth_id":      "test",
+					},
+				},
+				{
+					Record: "sloth_slo_info",
+					Expr:   `vector(1)`,
+					Labels: map[string]string{
+						"kind":            "test",
+						"sloth_service":   "test-svc",
+						"sloth_slo":       "test-name",
+						"sloth_id":        "test",
+						"sloth_version":   "test-ver",
+						"sloth_mode":      "test",
+						"sloth_spec":      "test/v1",
+						"sloth_objective": "99.9",
+					},
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			gotRules, err := prometheus.MetadataRecordingRulesGenerator.GenerateMetadataRecordingRules(context.TODO(), test.info, test.slo, test.alertGroup)
+			gotRules, err := test.generator.GenerateMetadataRecordingRules(context.TODO(), test.info, test.slo, test.alertGroup)
 
 			if test.expErr {
 				assert.Error(err)


### PR DESCRIPTION
To be used when SLO has one metrics series and some labels change, to continue the same series in the recording rules. Ignore all other labels except for sloth_id.

Code is not ideal, a lot of copying and pasting the same methods, but this does not require many changes (upstream has no changes for almost 2 years), so we can live with duplicated logic.