### PR TITLE
Make 30d SLI aggregation resilient to NaN propagation

### DIFF
--- a/internal/prometheus/recording_rules.go
+++ b/internal/prometheus/recording_rules.go
@@ -166,7 +166,7 @@ func optimizedSLIRecordGenerator(slo SLO, window, shortWindow time.Duration) (*r
 	// that is 1 (thats why we can use `count`), giving use a correct ratio of ratios:
 	// - https://prometheus.io/docs/practices/rules/
 	// - https://math.stackexchange.com/questions/95909/why-is-an-average-of-an-average-usually-incorrect
-	const sliExprTplFmt = `sum_over_time({{.metric}}{{.filter}}[{{.window}}])/43200`
+	const sliExprTplFmt = `sum_over_time(({{.metric}}{{.filter}} >= 0)[{{.window}}:1m])/43200`
 
 	if window == shortWindow {
 		return nil, fmt.Errorf("can't optimize using the same shortwindow as the window to optimize")
@@ -213,7 +213,7 @@ func optimizedBySlothIDSLIRecordGenerator(slo SLO, window, shortWindow time.Dura
 	// that is 1 (thats why we can use `count`), giving use a correct ratio of ratios:
 	// - https://prometheus.io/docs/practices/rules/
 	// - https://math.stackexchange.com/questions/95909/why-is-an-average-of-an-average-usually-incorrect
-	const sliExprTplFmt = `sum by (sloth_id) (sum_over_time({{.metric}}{{.filter}}[{{.window}}]))/43200`
+	const sliExprTplFmt = `sum by (sloth_id) (sum_over_time(({{.metric}}{{.filter}} >= 0)[{{.window}}:1m]))/43200`
 
 	if window == shortWindow {
 		return nil, fmt.Errorf("can't optimize using the same shortwindow as the window to optimize")

--- a/internal/prometheus/recording_rules_test.go
+++ b/internal/prometheus/recording_rules_test.go
@@ -187,7 +187,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30d",
-					Expr:   "sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
+					Expr:   "sum_over_time((slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"} >= 0)[30d:1m])/43200",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -297,7 +297,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30d",
-					Expr:   "sum by (sloth_id) (sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\"}[30d]))\n/\nsum by (sloth_id) (count_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\"}[30d]))\n",
+					Expr:   "sum by (sloth_id) (sum_over_time((slo:sli_error:ratio_rate5m{sloth_id=\"test\"} >= 0)[30d:1m]))/43200",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -516,7 +516,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30d",
-					Expr:   "sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
+					Expr:   "sum_over_time((slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"} >= 0)[30d:1m])/43200",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -587,7 +587,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30d",
-					Expr:   "sum_over_time(slo:sli_error:ratio_rate3h{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate3h{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
+					Expr:   "sum_over_time((slo:sli_error:ratio_rate3h{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"} >= 0)[30d:1m])/43200",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",


### PR DESCRIPTION
## Summary

- Adds `>= 0` filter to `sum_over_time` in the optimized 30d SLI recording rules (`optimizedSLIRecordGenerator` and `optimizedBySlothIDSLIRecordGenerator`)
- Drops NaN samples before aggregation, preventing a single NaN value from corrupting the entire 30-day error budget calculation
- Fixes tests that were not updated after the `/43200` constant divisor change

## Context

`sum_over_time()` returns NaN if any input sample is NaN. A single NaN in `slo:sli_error:ratio_rate5m` corrupts `ratio_rate30d` for up to 30 days, which cascades to `period_error_budget_remaining`.

The `>= 0` filter evaluates to false for NaN (`NaN >= 0` is false in IEEE 754), so NaN samples are dropped. Valid error ratios (always 0..1) pass through unchanged.

## Test plan

- [x] Updated unit tests for all optimized 30d rule generators
- [x] `go test ./internal/prometheus/...` passes